### PR TITLE
PRD-3122 - Add "format" to probe result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,5 @@ pip-selfcheck.json
 
 # Other
 MANIFEST
+*.env
+.vscode/*

--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -30,14 +30,13 @@ class FFProbe:
 
         if os.path.isfile(self.path_to_video) or self.path_to_video.startswith('http'):
             if platform.system() == 'Windows':
-                cmd = ["ffprobe", "-show_streams", self.path_to_video]
+                cmd = ["ffprobe", "-show_streams", "-show_format", self.path_to_video]
             else:
                 cmd = ["ffprobe -show_streams " + pipes.quote(self.path_to_video)]
 
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 
-            stream = False
-            ignoreLine = False
+            aggregate_lines = False
             self.streams = []
             self.video = []
             self.audio = []
@@ -49,16 +48,20 @@ class FFProbe:
                 line = line.decode('UTF-8', 'ignore')
 
                 if '[STREAM]' in line:
-                    stream = True
-                    ignoreLine = False
+                    aggregate_lines = True
                     data_lines = []
-                elif '[/STREAM]' in line and stream:
+                elif '[/STREAM]' in line and aggregate_lines:
                     stream = False
-                    ignoreLine = False
                     # noinspection PyUnboundLocalVariable
                     self.streams.append(FFStream(data_lines))
-                elif stream:
-                    if '=' in line and ignoreLine == False:
+                elif '[FORMAT]' in line:
+                    aggregate_lines = True
+                    data_lines = []
+                elif '[/FORMAT]' in line and aggregate_lines:
+                    aggregate_lines = False
+                    self.format = FFFormat(data_lines)
+                elif aggregate_lines:
+                    if '=' in line:
                         data_lines.append(line)
 
             self.metadata = {}
@@ -82,12 +85,18 @@ class FFProbe:
                             self.metadata[m.groups()[0]] = m.groups()[1].strip()
 
                 if '[STREAM]' in line:
-                    stream = True
+                    aggregate_lines = True
                     data_lines = []
                 elif '[/STREAM]' in line and stream:
-                    stream = False
+                    aggregate_lines = False
                     self.streams.append(FFStream(data_lines))
-                elif stream:
+                elif '[FORMAT]' in line:
+                    aggregate_lines = True
+                    data_lines = []
+                elif '[/FORMAT]' in line and aggregate_lines:
+                    aggregate_lines = False
+                    self.format = FFFormat(data_lines)
+                elif aggregate_lines:
                     data_lines.append(line)
 
                 if 'timecode' in line:
@@ -113,6 +122,14 @@ class FFProbe:
     def __repr__(self):
         return "<FFprobe: {metadata}, {video}, {audio}, {subtitle}, {attachment}, {timecode}>".format(**vars(self))
 
+
+class FFFormat:
+    """
+    An object representation of the overall container format of a multimedia file.
+    """
+    def __init__(self, data_lines):
+        for line in data_lines:
+            self.__dict__.update({key: value for key, value, *_ in [line.strip().split('=')]})
 
 class FFStream:
     """

--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -60,8 +60,7 @@ class FFProbe:
                 elif '[/FORMAT]' in line and aggregate_lines:
                     aggregate_lines = False
                     self.format = FFFormat(data_lines)
-                elif aggregate_lines:
-                    if '=' in line:
+                elif aggregate_lines and '=' in line:
                         data_lines.append(line)
 
             self.metadata = {}
@@ -96,7 +95,7 @@ class FFProbe:
                 elif '[/FORMAT]' in line and aggregate_lines:
                     aggregate_lines = False
                     self.format = FFFormat(data_lines)
-                elif aggregate_lines:
+                elif aggregate_lines and '=' in line:
                     data_lines.append(line)
 
                 if 'timecode' in line:

--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -294,3 +294,13 @@ class FFStream:
             return int(self.__dict__.get('bit_rate', ''))
         except ValueError:
             raise FFProbeError('None integer bit_rate')
+
+    def is_progressive(self):
+        if self.is_video() and self.__dict__.get('field_order', "") == "progressive":
+            return True
+        return False
+
+    def is_interlaced(self):
+        if self.is_video() and self.__dict__.get('field_order', "") in ["tt", "bb", "tb", "bt"]:
+            return True
+        return False

--- a/tests/ffprobe_test.py
+++ b/tests/ffprobe_test.py
@@ -27,8 +27,11 @@ def test_video ():
             try:
                 if stream.is_video():
                     frame_rate = stream.frames() / stream.duration_seconds()
-                    print('\t\tFrame Rate:', frame_rate)
-                    print('\t\tFrame Size:', stream.frame_size())
+                    print('\t\tFrame Rate :', frame_rate)
+                    print('\t\tFrame Size :', stream.frame_size())
+                    print('\t\tField order:', stream.field_order)
+                    print('\t\tProgressive:', stream.is_progressive())
+                    print('\t\tInterlaced :', stream.is_interlaced())
                 print('\t\tDuration:', stream.duration_seconds())
                 print('\t\tFrames:', stream.frames())
                 print('\t\tIs video:', stream.is_video())
@@ -53,6 +56,9 @@ def test_stream ():
                     frame_rate = stream.frames() / stream.duration_seconds()
                     print('\t\tFrame Rate:', frame_rate)
                     print('\t\tFrame Size:', stream.frame_size())
+                    print('\t\tField order:', stream.field_order)
+                    print('\t\tProgressive:', stream.is_progressive())
+                    print('\t\tInterlaced :', stream.is_interlaced())
                 print('\t\tDuration:', stream.duration_seconds())
                 print('\t\tFrames:', stream.frames())
                 print('\t\tIs video:', stream.is_video())

--- a/tests/ffprobe_test.py
+++ b/tests/ffprobe_test.py
@@ -38,6 +38,8 @@ def test_video ():
                 print(e)
             except Exception as e:
                 print(e)
+        print(f"\tFormat:\n\t\tDuration: {media.format.duration}")
+
 
 def test_stream ():
     for test_stream in test_streams:


### PR DESCRIPTION
This is intended to be used in pyprocessor batch_ingester as an alternate way of getting the duration when this is not available on the video stream
which is the case for FLV files (may be others)